### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 An implementation of JSON and JSON-RPC for Erlang.
 
 See
-[rfc4627.erl](http://tonyg.github.com/erlang-rfc4627/doc/rfc4627.html),
+[rfc4627.erl](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627.html),
 the JSON/RFC4627 codec itself, to learn how to encode and decode JSON
 objects from Erlang code.
 
 ## Providing and calling JSON-RPC services
 
 See
-[rfc4627\_jsonrpc.erl](http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc.html),
+[rfc4627\_jsonrpc.erl](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc.html),
 a JSON-RPC service registry and transport-neutral service method
 invocation mechanism, to learn how to expose Erlang processes as
 remotely-callable JSON-RPC services, and to learn how to invoke local
@@ -21,21 +21,21 @@ JSON-RPC services from Erlang without the overhead of HTTP.
 ### Using Inets
 
 See
-[rfc4627\_jsonrpc\_inets.erl](http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_inets.html),
+[rfc4627\_jsonrpc\_inets.erl](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_inets.html),
 an Inets HTTP transport binding for JSON-RPC, to learn how to
 configure the Inets HTTP server to respond to JSON-RPC requests.
 
 ### Using Mochiweb
 
 See
-[rfc4627\_jsonrpc\_mochiweb.erl](http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_mochiweb.html)
+[rfc4627\_jsonrpc\_mochiweb.erl](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_mochiweb.html)
 to learn how to delegate incoming Mochiweb HTTP requests to the
 JSON-RPC service dispatcher.
 
 ### Using Cowboy
 
 See
-[rfc4627\_jsonrpc\_cowboy.erl](http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_cowboy.html)
+[rfc4627\_jsonrpc\_cowboy.erl](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_cowboy.html)
 to learn how to delegate incoming Cowboy HTTP requests to the
 JSON-RPC service dispatcher.
 
@@ -67,17 +67,17 @@ service.
 ## Invoking JSON-RPC procedures from Javascript
 
 See the [relevant
-section](http://tonyg.github.com/erlang-rfc4627/doc/overview-summary.html#Invoking_JSON-RPC_procedures_from_Javascript)
+section](https://tonyg.github.com/erlang-rfc4627/doc/overview-summary.html#Invoking_JSON-RPC_procedures_from_Javascript)
 of the `edoc` documentation included with the source code.
 
 ## References
 
- - the [JSON RFC](http://www.ietf.org/rfc/rfc4627.txt).
+ - the [JSON RFC](https://www.ietf.org/rfc/rfc4627.txt).
 
  - the [JSON-RPC
-   specification](http://json-rpc.org/wd/JSON-RPC-1-1-WD-20060807.html)
+   specification](https://www.jsonrpc.org/wd/JSON-RPC-1-1-WD-20060807.html)
    1.1 working draft ([mirrored
-   locally](http://tonyg.github.com/erlang-rfc4627/doc/JSON-RPC-1-1-WD-20060807.html)).
+   locally](https://tonyg.github.com/erlang-rfc4627/doc/JSON-RPC-1-1-WD-20060807.html)).
 
  - Joe Armstrong's
    [message](http://erlang.org/pipermail/erlang-questions/2005-November/017805.html)

--- a/debian/postinst.ex
+++ b/debian/postinst.ex
@@ -14,7 +14,7 @@ set -e
 #        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
 #          <failed-install-package> <version> `removing'
 #          <conflicting-package> <version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 

--- a/debian/postrm.ex
+++ b/debian/postrm.ex
@@ -15,7 +15,7 @@ set -e
 #        * <new-postrm> `abort-upgrade' <old-version>
 #        * <disappearer's-postrm> `disappear' <overwriter>
 #          <overwriter-version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 

--- a/debian/preinst.ex
+++ b/debian/preinst.ex
@@ -10,7 +10,7 @@ set -e
 #        * <new-preinst> `install' <old-version>
 #        * <new-preinst> `upgrade' <old-version>
 #        * <old-preinst> `abort-upgrade' <new-version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 

--- a/debian/prerm.ex
+++ b/debian/prerm.ex
@@ -13,7 +13,7 @@ set -e
 #        * <deconfigured's-prerm> `deconfigure' `in-favour'
 #          <package-being-installed> <version> `removing'
 #          <conflicting-package> <version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
+# for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
 

--- a/src/doc/JSON-RPC-1-1-WD-20060807.html
+++ b/src/doc/JSON-RPC-1-1-WD-20060807.html
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"[]>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"[]>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
 <BASE HREF="http://json-rpc.org.wstub.archive.org/wd/JSON-RPC-1-1-WD-20060807.html">
 
     <title>JSON-RPC 1.1 Working Draft 7 August 2006</title>
-    <link rel="stylesheet" type="text/css" href="http://web.archive.org/web/20071224045515/http://json-rpc.org/wd/JSON-RPC-WD.css" />
+    <link rel="stylesheet" type="text/css" href="https://web.archive.org/web/20071224045515/http://json-rpc.org/wd/JSON-RPC-WD.css" />
   </head>
   <body>
     <h1 id="Title">
@@ -15,7 +15,7 @@
     <dl>
       <dt>Previous Versions:</dt>
       <dd>
-        <a href="http://json-rpc.org/wiki/specification">JSON-RPC 1.0</a>
+        <a href="https://www.jsonrpc.org/wiki/specification">JSON-RPC 1.0</a>
       </dd>
       <dt>Editors:</dt>
       <dd>
@@ -26,7 +26,7 @@
     <p>
         This document is currently a working draft published with the intent of
         soliciting community feedback. Please send your comments and concerns to the public mailing-list
-        <a href="http://groups.yahoo.com/group/json-rpc/">JSON-RPC Yahoo! Group</a>. Make
+        <a href="https://groups.yahoo.com/group/json-rpc/">JSON-RPC Yahoo! Group</a>. Make
         sure you prefix the subject line with “1.1WD:”, as in “1.1WD: Comment on errors”.
     </p>
     <p>
@@ -194,8 +194,8 @@
         Overview</h2>
     <p>
         JSON-RPC is a stateless and light-weight remote procedure call (<acronym title="Remote Procedure Call">RPC</acronym>) 
-        protocol for inter-networking applications over <a href="http://www.ietf.org/rfc/rfc2616.txt"><acronym title="Hypertext Transfer Protocol">HTTP</acronym></a>.
-        It uses <a href="http://www.ietf.org/rfc/rfc4627.txt"><acronym title="JavaScript Object Notation">JSON</acronym></a>
+        protocol for inter-networking applications over <a href="https://www.ietf.org/rfc/rfc2616.txt"><acronym title="Hypertext Transfer Protocol">HTTP</acronym></a>.
+        It uses <a href="https://www.ietf.org/rfc/rfc4627.txt"><acronym title="JavaScript Object Notation">JSON</acronym></a>
         as the data format for of all facets of a remote 
         procedure call, including all application data carried in parameters.</p>
     <p>
@@ -259,7 +259,7 @@
         The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT,
         SHOULD, SHOULD NOT, RECOMMENDED, MAY and OPTIONAL in this
         document are to be interpreted as described in 
-        <a href="http://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>.</p>
+        <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>.</p>
     <p>
         An implementation is not compliant if it fails to satisfy one or more
         of the MUST requirements for the protocols it implements.  An
@@ -353,13 +353,13 @@
     <p>
         For the remainder of this document, it is expected that the reader has some 
         familiarity with the basic syntax of JSON text. Otherwise, consult the 
-        <a href="http://www.ietf.org/rfc/rfc4627.txt">JSON specification (RFC 4627)</a>
+        <a href="https://www.ietf.org/rfc/rfc4627.txt">JSON specification (RFC 4627)</a>
         for further details.</p>
     <div class="ednote">
       <span class="editor">Atif Aziz:</span> It may be worth mentioning here how this specification makes a distinction
         between <em>JSON</em>, the abstract type system, and <em>JSON text</em>, the syntax
-        for serializing the values. In XML parlance, JSON is the <a href="http://www.w3.org/TR/xml-infoset/">
-            InfoSet</a> and JSON text is the equivalent of <a href="http://www.w3.org/TR/xml/">XML
+        for serializing the values. In XML parlance, JSON is the <a href="https://www.w3.org/TR/xml-infoset/">
+            InfoSet</a> and JSON text is the equivalent of <a href="https://www.w3.org/TR/xml/">XML
                 1.0</a>.</div>
     <p>
         This document also uses a specific convention to refer to any JSON type. 
@@ -371,8 +371,8 @@
     <p>
         A remote procedure call is made by sending a request to a remote service
         using either
-        <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5">HTTP POST</a> or
-        <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3">HTTP GET</a>.
+        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5">HTTP POST</a> or
+        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3">HTTP GET</a>.
         How and where the call is encoded within the HTTP message depends on the HTTP 
         method that is employed. In the case of HTTP POST, the procedure call is 
         carried in the body of the HTTP message whereas in the case of HTTP GET, it
@@ -402,7 +402,7 @@ Accept: application/json
     </div>
     <p>
         In this example, the method being targeted is provided by a 
-        service located at <code>http://www.example.com/myservice</code>.
+        service located at <code>https://www.example.com/myservice</code>.
         The call is expressed as a JSON Object in the body of the HTTP
         POST message. The <code>version</code> member of this object tells 
         the receiver the version of the JSON-RPC protocol being used by the 
@@ -440,12 +440,12 @@ Accept: application/json
         Regardless of whether a remote procedure call is made using
         HTTP GET or POST, the HTTP request message MUST specify the following headers:</p>
     <ul>
-      <li>The <code><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43">User-Agent</a></code> MUST be specified.</li>
-      <li>For HTTP POST only, the <code><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">Content-Type</a></code> MUST be specified and SHOULD read <code>application/json</code>.</li>
-      <li>The <code><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">Content-Length</a></code> MUST be specified and correct according
-            to the guidelines and rules laid out in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4">Section 4.4, “Message Length”</a>,
+      <li>The <code><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43">User-Agent</a></code> MUST be specified.</li>
+      <li>For HTTP POST only, the <code><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">Content-Type</a></code> MUST be specified and SHOULD read <code>application/json</code>.</li>
+      <li>The <code><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">Content-Length</a></code> MUST be specified and correct according
+            to the guidelines and rules laid out in <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4">Section 4.4, “Message Length”</a>,
             of the HTTP specification.</li>
-      <li>The <code><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1">Accept</a></code> MUST be specified and SHOULD read <code>application/json</code>.</li>
+      <li>The <code><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1">Accept</a></code> MUST be specified and SHOULD read <code>application/json</code>.</li>
     </ul>
     <h3 id="PostProcedureCall">6.2. Call Encoding Using HTTP POST</h3>
     <p>
@@ -621,7 +621,7 @@ Accept: application/json
         procedure's name MUST therefore be preceded by a forward-slash (U+002F or ASCII
         47) but MUST NOT end in one.</p>
     <p>
-        The parameters are placed in the <em>query component</em> (as defined in <a href="http://tools.ietf.org/html/3986">
+        The parameters are placed in the <em>query component</em> (as defined in <a href="https://tools.ietf.org/html/3986">
             RFC 3986</a>) of the Request-URI, which is then formatted using the same scheme as defined
         for <a href="http://www.w3.org/TR/html4/interact/forms.html">HTML Forms</a> with
         the <a href="http://www.w3.org/TR/html4/interact/forms.html#adef-method"><code>get</code> method</a>.
@@ -659,7 +659,7 @@ Accept: application/json
         Safe and Idempotent Procedures Only</h4>
     <p>
         Due to semantics and therefore requirements of HTTP GET, only procedures that are
-        considered safe and idempotent MAY be invoked using HTTP GET. An explanation of what is considered safe and idempotent is provided in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.1">
+        considered safe and idempotent MAY be invoked using HTTP GET. An explanation of what is considered safe and idempotent is provided in <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.1">
             Section 9.1 (Safe and Idempotent Methods)</a> of HTTP 1.1 specificiation. A
         server SHOULD provide a means (through a configuration file, for example) for a
         service to indicate which of its procedures are safe and idempotent in order to
@@ -738,22 +738,22 @@ Accept: application/json
     <p>
         When the call is made using HTTP GET, the HTTP status code for a successful result
         SHOULD be 200. If the HTTP GET call requested cache validation as well, the response
-        MAY be <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">304 (Not Modified)</a>.
-        The use of status codes generally related to redirection (e.g., <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3">302 “Found”</a> or
-        <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">301 “Moved Permanently”</a>) of HTTP GET transactions is not strictly prohibited, but service providers are RECOMMENDED
+        MAY be <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5">304 (Not Modified)</a>.
+        The use of status codes generally related to redirection (e.g., <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.3">302 “Found”</a> or
+        <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2">301 “Moved Permanently”</a>) of HTTP GET transactions is not strictly prohibited, but service providers are RECOMMENDED
         instead to use public documentation and communication methods to advertise the relocation
         of a service.</p>
     <p>
-        Clients SHOULD be prepared to handle a status code of <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">
+        Clients SHOULD be prepared to handle a status code of <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2">
             401 (Unauthorized)</a> resulting from an authentication challenge when a call
         is sent anonymously.</p>
     <p>
-        Unless noted otherwise, a status code of <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">
+        Unless noted otherwise, a status code of <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1">
         500 (Internal Server Error)</a> MUST be used under the following conditions:</p>
     <ul>
       <li>There was an error parsing the JSON text comprising the Procedure Call.</li>
       <li>The target procedure does not exist on the server. For HTTP GET, a server SHOULD
-            use <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">404 (Not
+            use <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">404 (Not
                 Found)</a> instead of 500.</li>
       <li>The procedure could not be invoked due to an error resulting from <a href="#CallApproximation">
             call approximation</a>.</li>
@@ -763,9 +763,9 @@ Accept: application/json
     <p>
         Regardless of the HTTP method used to make the remote procedure call, the HTTP response message MUST specify the following headers:</p>
     <ul>
-      <li>The <code><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">Content-Type</a></code> MUST be specified and SHOULD read <code>application/json</code>.</li>
-      <li>The <code><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">Content-Length</a></code> MUST be specified and correct according
-            to the guidelines and rules laid out in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4">Section 4.4, “Message Length”</a>,
+      <li>The <code><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">Content-Type</a></code> MUST be specified and SHOULD read <code>application/json</code>.</li>
+      <li>The <code><a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">Content-Length</a></code> MUST be specified and correct according
+            to the guidelines and rules laid out in <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4">Section 4.4, “Message Length”</a>,
             of the HTTP specification.</li>
     </ul>
     <h3 id="Head25">7.3. 
@@ -952,7 +952,7 @@ Server: Microsoft-IIS/6.0
       <dt>id</dt>
       <dd>
             REQUIRED. A String value that uniquely and globally identifies the service. The
-            string MUST use the <a href="http://tools.ietf.org/html/rfc3986">URI Generic Syntax
+            string MUST use the <a href="https://tools.ietf.org/html/rfc3986">URI Generic Syntax
                 (RFC 3986)</a>.
         </dd>
       <dt>version</dt>
@@ -1103,7 +1103,7 @@ Server: Microsoft-IIS/6.0
         Service Description Example</h3>
     <p>
         Below is an example of Service Description object that describes a fictious DemoService
-        service that resides at the address <code>http://www.example.com/service</code> and which publishes
+        service that resides at the address <code>https://www.example.com/service</code> and which publishes
         a single procedure called <code>sum</code> with two Number parameters, namely <code>a</code> and <code>b</code>,
         and which returns a Number result.</p>
     <div class="exampleOuter">
@@ -1114,13 +1114,13 @@ Server: Microsoft-IIS/6.0
     "name"    : "DemoService",
     "id"      : "urn:uuid:41544946-415a-495a-5645-454441534646",
     "summary" : "A simple demonstration service.",
-    "help"    : "http://www.example.com/service/index.html",
-    "address" : "http://www.example.com/service",
+    "help"    : "https://www.example.com/service/index.html",
+    "address" : "https://www.example.com/service",
     "procs" : [ 
         {
             "name"    : "sum",
             "summary" : "Sums two numbers.",
-            "help"    : "http://www.example.com/service/sum.html",
+            "help"    : "https://www.example.com/service/sum.html",
             "params"  : [ 
                 { "name" : "a", "type" : "num" }, 
                 { "name" : "b", "type" : "num" } ],
@@ -1130,7 +1130,7 @@ Server: Microsoft-IIS/6.0
         {
             "name"    : "time",
             "summary" : "Returns the current date and time in ISO 8601 format.",
-            "help"    : "http://www.example.com/service/time.html",
+            "help"    : "https://www.example.com/service/time.html",
             "return" : {
                 "type" : "string" 
         } 
@@ -1142,7 +1142,7 @@ Server: Microsoft-IIS/6.0
         Language of the Description Objects</h3>
     <p>
         The <code>summary</code> members of the Service Description and Procedure Description objects
-        contain human-readable text. A service MAY use the <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
+        contain human-readable text. A service MAY use the <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
             Accept-Language</a> header from the HTTP request message to deliver a localized
         text for its String value. Likewise, the URL for the <code>help</code> members MAY 
         also point a page that contains the localized documentation. However, the documentation
@@ -1175,7 +1175,7 @@ Server: Microsoft-IIS/6.0
     <div class="ednote">
       <span class="editor">Atif Aziz:</span>
         The reason for choosing the Dollar sign is related to the JavaScript heritage.
-        According to the <a href="http://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript 
+        According to the <a href="https://www.ecma-international.org/publications/standards/Ecma-262.htm">ECMAScript 
         Language Specification (ECMA-262)</a>, “The Dollar sign is intended for use only in
         mechanically generated code.” Although the general convention in Internet
         protocols is to use the letter X followed by a dash (U+002D
@@ -1183,11 +1183,11 @@ Server: Microsoft-IIS/6.0
         and appropriate fit for JSON-RPC. <em>Should we really be caring about the JavaScript/JSON
         heritage in a communication protocol?</em> One downside of using Dollar sign is that
         it reserved in the Query component of the 
-        <a href="http://www.ietf.org/rfc/rfc2396.txt">URI Generic Syntax (RFC 2396)</a>.
+        <a href="https://www.ietf.org/rfc/rfc2396.txt">URI Generic Syntax (RFC 2396)</a>.
     </div>
     <div class="ednote">
       <span class="editor">Atif Aziz:</span>
-        Add comment about <a href="http://en.wikipedia.org/wiki/Common_Gateway_Interface"><acronym title="Common Gateway Interface">CGI</acronym></a>
+        Add comment about <a href="https://en.wikipedia.org/wiki/Common_Gateway_Interface"><acronym title="Common Gateway Interface">CGI</acronym></a>
         binding for extensions on the <a href="#PostProcedureCall">Procedure Call</a> object?</div>
     <h2 id="OverallLimitations">13. 
         Limitations</h2>
@@ -1221,7 +1221,7 @@ OF THE INTERNET ARCHIVE IN ORDER TO PRESERVE THE TEMPORAL INTEGRITY OF THE SESSI
 // ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
 // SECTION 108(a)(3)).
 
-   var sWayBackCGI = "http://web.archive.org/web/20071224045515/";
+   var sWayBackCGI = "https://web.archive.org/web/20071224045515/";
 
    function xResolveUrl(url) {
       var image = new Image();

--- a/src/doc/overview.edoc.in
+++ b/src/doc/overview.edoc.in
@@ -5,11 +5,11 @@
 
 @version %%VERSION%%
 
-@reference <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>,
+@reference <a href="https://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>,
 the JSON RFC
 
 @reference The <a
-href="http://json-rpc.org/wd/JSON-RPC-1-1-WD-20060807.html">JSON-RPC
+href="https://www.jsonrpc.org/wd/JSON-RPC-1-1-WD-20060807.html">JSON-RPC
 specification</a> 1.1 working draft (<a
 href="JSON-RPC-1-1-WD-20060807.html">mirrored locally</a>).
 

--- a/src/rfc4627.erl
+++ b/src/rfc4627.erl
@@ -26,10 +26,10 @@
 %% SOFTWARE.
 %%---------------------------------------------------------------------------
 %%
-%% @reference <a href="http://www.ietf.org/rfc/rfc4627.txt">RFC
+%% @reference <a href="https://www.ietf.org/rfc/rfc4627.txt">RFC
 %% 4627</a>, the JSON RFC
 %%
-%% @reference <a href="http://www.json.org/">JSON in general</a>
+%% @reference <a href="https://www.json.org/">JSON in general</a>
 %%
 %% @reference Joe Armstrong's <a
 %% href="http://erlang.org/pipermail/erlang-questions/2005-November/017805.html">
@@ -43,7 +43,7 @@
 %% == Data Type Mapping ==
 %%
 %% The data type mapping I've implemented is as per Joe Armstrong's
-%% message [http://www.erlang.org/ml-archive/erlang-questions/200511/msg00193.html] - see {@link json()}.
+%% message [https://www.erlang.org/ml-archive/erlang-questions/200511/msg00193.html] - see {@link json()}.
 %%
 %% == Unicode ==
 %%
@@ -292,10 +292,10 @@ decode_noauto(Chars) ->
 %% if present, even though RFC4627 explicitly notes that the first two
 %% characters of a JSON text will be ASCII.
 %%
-%% If a BOM ([http://unicode.org/faq/utf_bom.html]) is present, we use
+%% If a BOM ([https://unicode.org/faq/utf_bom.html]) is present, we use
 %% that; if not, we use RFC4627's rules (as above). Note that UTF-32
 %% is the same as UCS-4 for our purposes (but see also
-%% [http://unicode.org/reports/tr19/tr19-9.html]). Note that UTF-16 is
+%% [https://unicode.org/reports/tr19/tr19-9.html]). Note that UTF-16 is
 %% not the same as UCS-2!
 %%
 %% Note that I'm using xmerl's UCS/UTF support here. There's another

--- a/src/rfc4627_jsonrpc.erl
+++ b/src/rfc4627_jsonrpc.erl
@@ -27,7 +27,7 @@
 %%---------------------------------------------------------------------------
 %% @since 1.2.0
 %%
-%% @reference the <a href="http://json-rpc.org/wd/JSON-RPC-1-1-WD-20060807.html">JSON-RPC specification</a> (draft; <a href="JSON-RPC-1-1-WD-20060807.html">mirrored locally</a>)
+%% @reference the <a href="https://www.jsonrpc.org/wd/JSON-RPC-1-1-WD-20060807.html">JSON-RPC specification</a> (draft; <a href="JSON-RPC-1-1-WD-20060807.html">mirrored locally</a>)
 %%
 %% @doc Provides a registry of running JSON-RPC objects, and a
 %% transport-neutral means of invoking methods defined on such

--- a/src/rfc4627_jsonrpc_cowboy.erl
+++ b/src/rfc4627_jsonrpc_cowboy.erl
@@ -27,7 +27,7 @@
 %% SOFTWARE.
 %%---------------------------------------------------------------------------
 %%
-%% @reference the <a href="http://github.com/extend/cowboy/">Cowboy github page</a>
+%% @reference the <a href="https://github.com/extend/cowboy/">Cowboy github page</a>
 %%
 %% @doc Support for serving JSON-RPC via Cowboy.
 %%

--- a/src/rfc4627_jsonrpc_mochiweb.erl
+++ b/src/rfc4627_jsonrpc_mochiweb.erl
@@ -27,7 +27,7 @@
 %%---------------------------------------------------------------------------
 %% @since 1.2.0
 %%
-%% @reference the <a href="http://code.google.com/p/mochiweb/">Mochiweb home page</a>
+%% @reference the <a href="https://code.google.com/p/mochiweb/">Mochiweb home page</a>
 %%
 %% @doc Support for serving JSON-RPC via Mochiweb.
 %%

--- a/test/server_root/htdocs/json.js
+++ b/test/server_root/htdocs/json.js
@@ -1,16 +1,16 @@
 /*
-    http://www.JSON.org/json2.js
+    https://www.JSON.org/json2.js
     2010-08-25
 
     Public Domain.
 
     NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
 
-    See http://www.JSON.org/js.html
+    See https://www.JSON.org/js.html
 
 
     This code should be minified before deployment.
-    See http://javascript.crockford.com/jsmin.html
+    See https://javascript.crockford.com/jsmin.html
 
     USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
     NOT CONTROL.

--- a/test/server_root/htdocs/prototype-1.4.0.js
+++ b/test/server_root/htdocs/prototype-1.4.0.js
@@ -2,7 +2,7 @@
  *  (c) 2005 Sam Stephenson <sam@conio.net>
  *
  *  Prototype is freely distributable under the terms of an MIT-style license.
- *  For details, see the Prototype web site: http://prototype.conio.net/
+ *  For details, see the Prototype web site: https://prototype.conio.net/
  *
 /*--------------------------------------------------------------------------*/
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://erlang.org/pipermail/erlang-questions/2005-November/017805.html (200) with 2 occurrences could not be migrated:  
   ([https](https://erlang.org/pipermail/erlang-questions/2005-November/017805.html) result ConnectTimeoutException).
* http://jan.kollhof.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://jan.kollhof.net/) result ClosedChannelException).
* http://www.raboof.com/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.raboof.com/) result NativeIoException).
* http://json-rpc.org.wstub.archive.org/wd/JSON-RPC-1-1-WD-20060807.html (404) with 1 occurrences could not be migrated:  
   ([https](https://json-rpc.org.wstub.archive.org/wd/JSON-RPC-1-1-WD-20060807.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).
* http://prototype.conio.net/ (UnknownHostException) with 1 occurrences migrated to:  
  https://prototype.conio.net/ ([https](https://prototype.conio.net/) result UnknownHostException).
* http://www.JSON.org/js.html (404) with 1 occurrences migrated to:  
  https://www.JSON.org/js.html ([https](https://www.JSON.org/js.html) result 404).
* http://www.JSON.org/json2.js (404) with 1 occurrences migrated to:  
  https://www.JSON.org/json2.js ([https](https://www.JSON.org/json2.js) result 404).
* http://www.erlang.org/ml-archive/erlang-questions/200511/msg00193.html (404) with 1 occurrences migrated to:  
  https://www.erlang.org/ml-archive/erlang-questions/200511/msg00193.html ([https](https://www.erlang.org/ml-archive/erlang-questions/200511/msg00193.html) result 404).
* http://www.example.com/myservice (404) with 1 occurrences migrated to:  
  https://www.example.com/myservice ([https](https://www.example.com/myservice) result 404).
* http://www.example.com/service (404) with 2 occurrences migrated to:  
  https://www.example.com/service ([https](https://www.example.com/service) result 404).
* http://www.example.com/service/index.html (404) with 1 occurrences migrated to:  
  https://www.example.com/service/index.html ([https](https://www.example.com/service/index.html) result 404).
* http://www.example.com/service/sum.html (404) with 1 occurrences migrated to:  
  https://www.example.com/service/sum.html ([https](https://www.example.com/service/sum.html) result 404).
* http://www.example.com/service/time.html (404) with 1 occurrences migrated to:  
  https://www.example.com/service/time.html ([https](https://www.example.com/service/time.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://en.wikipedia.org/wiki/Common_Gateway_Interface with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Common_Gateway_Interface ([https](https://en.wikipedia.org/wiki/Common_Gateway_Interface) result 200).
* http://tools.ietf.org/html/rfc3986 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc3986 ([https](https://tools.ietf.org/html/rfc3986) result 200).
* http://unicode.org/faq/utf_bom.html with 1 occurrences migrated to:  
  https://unicode.org/faq/utf_bom.html ([https](https://unicode.org/faq/utf_bom.html) result 200).
* http://unicode.org/reports/tr19/tr19-9.html with 1 occurrences migrated to:  
  https://unicode.org/reports/tr19/tr19-9.html ([https](https://unicode.org/reports/tr19/tr19-9.html) result 200).
* http://www.debian.org/doc/debian-policy/ with 4 occurrences migrated to:  
  https://www.debian.org/doc/debian-policy/ ([https](https://www.debian.org/doc/debian-policy/) result 200).
* http://www.ecma-international.org/publications/standards/Ecma-262.htm with 1 occurrences migrated to:  
  https://www.ecma-international.org/publications/standards/Ecma-262.htm ([https](https://www.ecma-international.org/publications/standards/Ecma-262.htm) result 200).
* http://www.ietf.org/rfc/rfc2119.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2119.txt ([https](https://www.ietf.org/rfc/rfc2119.txt) result 200).
* http://www.ietf.org/rfc/rfc2396.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2396.txt ([https](https://www.ietf.org/rfc/rfc2396.txt) result 200).
* http://www.ietf.org/rfc/rfc2616.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2616.txt ([https](https://www.ietf.org/rfc/rfc2616.txt) result 200).
* http://www.ietf.org/rfc/rfc4627.txt with 5 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc4627.txt ([https](https://www.ietf.org/rfc/rfc4627.txt) result 200).
* http://www.json.org/ with 1 occurrences migrated to:  
  https://www.json.org/ ([https](https://www.json.org/) result 200).
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html with 6 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) result 200).
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html with 7 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) result 200).
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html with 2 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html) result 200).
* http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html with 3 occurrences migrated to:  
  https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html ([https](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) result 200).
* http://www.w3.org/TR/xml-infoset/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/xml-infoset/ ([https](https://www.w3.org/TR/xml-infoset/) result 200).
* http://www.w3.org/TR/xml/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/xml/ ([https](https://www.w3.org/TR/xml/) result 200).
* http://code.google.com/p/mochiweb/ with 1 occurrences migrated to:  
  https://code.google.com/p/mochiweb/ ([https](https://code.google.com/p/mochiweb/) result 301).
* http://github.com/extend/cowboy/ with 1 occurrences migrated to:  
  https://github.com/extend/cowboy/ ([https](https://github.com/extend/cowboy/) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/JSON-RPC-1-1-WD-20060807.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/JSON-RPC-1-1-WD-20060807.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/JSON-RPC-1-1-WD-20060807.html) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/overview-summary.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/overview-summary.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/overview-summary.html) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/rfc4627.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/rfc4627.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627.html) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc.html) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_cowboy.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_cowboy.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_cowboy.html) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_inets.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_inets.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_inets.html) result 301).
* http://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_mochiweb.html with 1 occurrences migrated to:  
  https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_mochiweb.html ([https](https://tonyg.github.com/erlang-rfc4627/doc/rfc4627_jsonrpc_mochiweb.html) result 301).
* http://json-rpc.org/wiki/specification (302) with 1 occurrences migrated to:  
  https://www.jsonrpc.org/wiki/specification ([https](https://json-rpc.org/wiki/specification) result 301).
* http://groups.yahoo.com/group/json-rpc/ with 1 occurrences migrated to:  
  https://groups.yahoo.com/group/json-rpc/ ([https](https://groups.yahoo.com/group/json-rpc/) result 302).
* http://javascript.crockford.com/jsmin.html with 1 occurrences migrated to:  
  https://javascript.crockford.com/jsmin.html ([https](https://javascript.crockford.com/jsmin.html) result 302).
* http://tools.ietf.org/html/3986 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/3986 ([https](https://tools.ietf.org/html/3986) result 302).
* http://web.archive.org/web/20071224045515/ with 1 occurrences migrated to:  
  https://web.archive.org/web/20071224045515/ ([https](https://web.archive.org/web/20071224045515/) result 302).
* http://web.archive.org/web/20071224045515/http://json-rpc.org/wd/JSON-RPC-WD.css with 1 occurrences migrated to:  
  https://web.archive.org/web/20071224045515/http://json-rpc.org/wd/JSON-RPC-WD.css ([https](https://web.archive.org/web/20071224045515/https://json-rpc.org/wd/JSON-RPC-WD.css) result 302).
* http://json-rpc.org/wd/JSON-RPC-1-1-WD-20060807.html (302) with 3 occurrences migrated to:  
  https://www.jsonrpc.org/wd/JSON-RPC-1-1-WD-20060807.html ([https](https://json-rpc.org/wd/JSON-RPC-1-1-WD-20060807.html) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:5671/ with 3 occurrences
* http://localhost:5671/rpc/ with 2 occurrences
* http://localhost:5671/rpc/test with 1 occurrences
* http://localhost:5671/rpc/test/system.describe with 1 occurrences
* http://www.w3.org/1999/xhtml with 1 occurrences
* http://www.w3.org/TR/html4/interact/forms.html with 2 occurrences